### PR TITLE
Set default options in case options are never persisted to local storage (i.e. options page is never viewed)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "manifest_version": 3,
     "name": "Lumos",
     "description": "An LLM co-pilot for browsing the web, powered by local LLMs. Your prompts never leave the browser.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumos",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "dependencies": {
     "@chatscope/chat-ui-kit-react": "^1.10.1",

--- a/src/components/ChatBar.tsx
+++ b/src/components/ChatBar.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { Alert, Box, IconButton, Snackbar, TextField, Tooltip } from "@mui/material";
 import { Avatar, ChatContainer, Message, MessageList, TypingIndicator } from "@chatscope/chat-ui-kit-react";
+import { DEFAULT_CONTENT_CONFIG } from "../pages/Options";
 import { ContentConfig } from "../contentConfig";
 import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';
 import "./ChatBar.css";
@@ -104,7 +105,7 @@ const ChatBar: React.FC = () => {
         if (chrome.runtime.lastError) {
           reject(chrome.runtime.lastError);
         } else {
-          resolve(JSON.parse(data.selectedConfig) as ContentConfig);
+          resolve(JSON.parse(data.selectedConfig || DEFAULT_CONTENT_CONFIG) as ContentConfig);
         }
       });
     });

--- a/src/pages/Options.tsx
+++ b/src/pages/Options.tsx
@@ -14,12 +14,16 @@ import { defaultContentConfig, isContentConfig } from "../contentConfig";
 import "./Options.css";
 
 
+export const DEFAULT_MODEL = "llama2";
+export const DEFAULT_HOST = "http://localhost:11434";
+export const DEFAULT_CONTENT_CONFIG = JSON.stringify(defaultContentConfig, null, 2);
+
 function Options() {
 
-  const [model, setModel] = useState("");
+  const [model, setModel] = useState(DEFAULT_MODEL);
   const [modelOptions, setModelOptions] = useState([]);
-  const [host, setHost] = useState("http://localhost:11434");
-  const [contentConfig, setContentConfig] = useState(JSON.stringify(defaultContentConfig, null, 2));
+  const [host, setHost] = useState(DEFAULT_HOST);
+  const [contentConfig, setContentConfig] = useState(DEFAULT_CONTENT_CONFIG);
   const [contentConfigError, setContentConfigError] = useState(false);
   const [contentConfigHelpText, setContentConfigHelpText] = useState("");
 

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -6,6 +6,7 @@ import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import { StringOutputParser } from "langchain/schema/output_parser";
 import { RunnableSequence, RunnablePassthrough } from "langchain/schema/runnable";
 import { formatDocumentsAsString } from "langchain/util/document";
+import { DEFAULT_CONTENT_CONFIG, DEFAULT_HOST, DEFAULT_MODEL } from "../pages/Options";
 import { ContentConfig } from "../contentConfig";
 
 
@@ -27,9 +28,9 @@ chrome.runtime.onMessage.addListener(async function (request) {
           reject(chrome.runtime.lastError);
         } else {
           resolve({
-            ollamaModel: data.selectedModel,
-            ollamaHost: data.selectedHost,
-            contentConfig: JSON.parse(data.selectedConfig) as ContentConfig,
+            ollamaModel: data.selectedModel || DEFAULT_MODEL,
+            ollamaHost: data.selectedHost || DEFAULT_HOST,
+            contentConfig: JSON.parse(data.selectedConfig || DEFAULT_CONTENT_CONFIG) as ContentConfig,
           });
         }
       });

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -95,3 +95,10 @@ chrome.runtime.onMessage.addListener(async function (request) {
     console.log(`Received context: ${context}`);
   }
 });
+
+const keepAlive = () => {
+  setInterval(chrome.runtime.getPlatformInfo, 20e3);
+  console.log("Keep alive...");
+}
+chrome.runtime.onStartup.addListener(keepAlive);
+keepAlive();


### PR DESCRIPTION
This causes an error when running the app without viewing the options page.