### PR TITLE
Cache vector stores, expose/optimize search parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Right-click on the extension icon to and select `Options` to access the extensio
 
 - **Ollama Model**: Select desired model (e.g. `llama2`)
 - **Ollama Host**: Select desired host (defaults to `http://0.0.0.0:11434`)
+- **Vector Store TTL (minutes)**: Number of minutes to store a URL's content in the vector store cache.
 - **Content Parser Config**: Lumos's default content parser will extract all text content between a page's `<body></body>` tag. To customize the content parser, add an entry to the configuration.
 
 ### Content Parser Config

--- a/src/components/ChatBar.tsx
+++ b/src/components/ChatBar.tsx
@@ -109,12 +109,14 @@ const ChatBar: React.FC = () => {
         }
       });
     });
+
     var config = contentConfig["default"];
+    var activeTabUrl: URL;
 
     chrome.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
       const activeTab = tabs[0];
       const activeTabId = activeTab.id;
-      const activeTabUrl = new URL(activeTab.url || "");
+      activeTabUrl = new URL(activeTab.url || "");
       const domain = getDomain(activeTabUrl.hostname);
 
       // get domain specific content config
@@ -134,6 +136,7 @@ const ChatBar: React.FC = () => {
           prompt: prompt,
           chunkSize: config.chunkSize,
           chunkOverlap: config.chunkOverlap,
+          url: activeTabUrl.toString(),
         });
 
         // clear prompt after sending it to the background script

--- a/src/pages/Options.css
+++ b/src/pages/Options.css
@@ -1,6 +1,6 @@
 .options-popup {
   width: 500px;
-  height: 400px;
+  height: 450px;
   box-sizing: border-box;
   padding-top: 10px;
   padding-bottom: 10px;

--- a/src/pages/Options.tsx
+++ b/src/pages/Options.tsx
@@ -17,6 +17,7 @@ import "./Options.css";
 export const DEFAULT_MODEL = "llama2";
 export const DEFAULT_HOST = "http://localhost:11434";
 export const DEFAULT_CONTENT_CONFIG = JSON.stringify(defaultContentConfig, null, 2);
+export const DEFAULT_VECTOR_STORE_TTL_MINS = 60;
 
 function Options() {
 
@@ -26,6 +27,7 @@ function Options() {
   const [contentConfig, setContentConfig] = useState(DEFAULT_CONTENT_CONFIG);
   const [contentConfigError, setContentConfigError] = useState(false);
   const [contentConfigHelpText, setContentConfigHelpText] = useState("");
+  const [vectorStoreTTLMins, setVectorStoreTTLMins] = useState(DEFAULT_VECTOR_STORE_TTL_MINS);
 
   const handleModelChange = (event: SelectChangeEvent) => {
     const selectedModel = event.target.value;
@@ -53,13 +55,22 @@ function Options() {
     }
   };
 
+  const handleVectorStoreTTLMinsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedVectorStoreTTLMins = parseInt(event.target.value, 10);
+    setVectorStoreTTLMins(selectedVectorStoreTTLMins);
+    chrome.storage.local.set({ selectedVectorStoreTTLMins: selectedVectorStoreTTLMins});
+  };
+
   useEffect(() => {
-    chrome.storage.local.get(["selectedHost", "selectedConfig"]).then((data) => {
+    chrome.storage.local.get(["selectedHost", "selectedConfig", "selectedVectorStoreTTLMins"]).then((data) => {
       if (data.selectedHost) {
         setHost(data.selectedHost);
       }
       if (data.selectedConfig) {
         setContentConfig(data.selectedConfig);
+      }
+      if (data.selectedVectorStoreTTLMins) {
+        setVectorStoreTTLMins(parseInt(data.selectedVectorStoreTTLMins, 10));
       }
     });
   }, []);
@@ -109,6 +120,13 @@ function Options() {
               label="Ollama Host"
               value={host}
               onChange={handleHostChange}
+            />
+            <TextField
+              sx={{"margin-bottom": "15px"}}
+              type="number"
+              label="Vector Store TTL (minutes)"
+              value={vectorStoreTTLMins}
+              onChange={handleVectorStoreTTLMinsChange}
             />
             <TextField
               sx={{"margin-bottom": "15px"}}


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/andrewnguonly/Lumos/issues/42.

General comments:
1. Chrome's background script memory is limited (i.e. can’t have too many documents stored in memory).
1. Most documents will become out of date after some time. Typically, users aren’t browsing the same websites constantly or the website's content is changing frequently.
1. Ideally, vector store documents should be deleted after a "browsing session" is complete.
1. Documents should not be indexed if they were just indexed.
1. Highlighted content is an exception. Highlighted content should always be indexed in a vector store for RAG retrieval.

### Design
An in-memory cache stores a `MemoryVectorStore` (w/ the embedded documents) for each unique URL. A `MemoryVectorStore` is retrieved for a URL if it already exists. Otherwise, a new `MemoryVectorStore` is created. `MemoryVectorStore`s are deleted after some preconfigured amount of time.

### Implementation
1. Add a `Vector Store TTL (minutes)` option to the Options page.
1. Update background script (`background.ts`) to retrieve `MemoryVectorStore` from the cache.

### Screenshot
![image](https://github.com/andrewnguonly/Lumos/assets/7654246/6947b9a6-4b43-4efc-bb3a-0b09c4872d8c)

### To Do
- [x] Implement workflow for handling highlighted content.
- [x] Investigate RAG search parameter optimization and update the PR if there are any simple changes. Otherwise, create a different PR.