### PR TITLE
Add Ollama API connectivity check and migrate to using full model name throughout app

### DIFF
--- a/src/components/ChatBar.tsx
+++ b/src/components/ChatBar.tsx
@@ -40,7 +40,9 @@ class LumosMessage {
 const ChatBar: React.FC = () => {
   const [prompt, setPrompt] = useState("");
   const [promptError, setPromptError] = useState(false);
-  const [promptPlaceholderText, setPromptPlaceholderText] = useState("Enter your prompt here");
+  const [promptPlaceholderText, setPromptPlaceholderText] = useState(
+    "Enter your prompt here",
+  );
   const [parsingDisabled, setParsingDisabled] = useState(false);
   const [completion, setCompletion] = useState("");
   const [messages, setMessages] = useState<LumosMessage[]>([]);
@@ -232,14 +234,17 @@ const ChatBar: React.FC = () => {
   });
 
   useEffect(() => {
-    chrome.storage.local.get(["chatContainerHeight", "selectedHost"], (data) => {
-      if (data.chatContainerHeight) {
-        setChatContainerHeight(data.chatContainerHeight);
-      }
-      if (data.selectedHost) {
-        setSelectedHost(data.selectedHost);
-      }
-    });
+    chrome.storage.local.get(
+      ["chatContainerHeight", "selectedHost"],
+      (data) => {
+        if (data.chatContainerHeight) {
+          setChatContainerHeight(data.chatContainerHeight);
+        }
+        if (data.selectedHost) {
+          setSelectedHost(data.selectedHost);
+        }
+      },
+    );
 
     chrome.storage.session.get(
       ["prompt", "parsingDisabled", "messages"],
@@ -270,7 +275,9 @@ const ChatBar: React.FC = () => {
       })
       .catch(() => {
         setPromptError(true);
-        setPromptPlaceholderText("Unable to connect to Ollama API. Check Ollama server.");
+        setPromptPlaceholderText(
+          "Unable to connect to Ollama API. Check Ollama server.",
+        );
       });
   }, [selectedHost]);
 

--- a/src/pages/Options.tsx
+++ b/src/pages/Options.tsx
@@ -106,9 +106,9 @@ function Options() {
     fetch(`${host}/api/tags`)
       .then((response) => response.json())
       .then((data) => {
-        const modelOptions = data.models.map((model: { name: string }) => {
-          return model.name.split(":")[0];
-        });
+        const modelOptions = data.models.map(
+          (model: { name: string }) => model.name,
+        );
         setModelOptions(modelOptions);
         chrome.storage.local.get(["selectedModel"]).then((data) => {
           if (data.selectedModel) {
@@ -136,9 +136,9 @@ function Options() {
               value={model}
               onChange={handleModelChange}
             >
-              {modelOptions.map((modelName, index) => (
+              {modelOptions.map((modelName: string, index) => (
                 <MenuItem key={index} value={modelName}>
-                  {modelName}
+                  {`${modelName.split(":")[0]} (${modelName.split(":")[1]})`}
                 </MenuItem>
               ))}
             </Select>


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/andrewnguonly/Lumos/issues/76.

### Implementation
1. Migrate to using the full model name (including tag). This change is backward compatible.
1. Set the prompt input field in an error state if the app cannot connect to the Ollama server.

### Screenshots
![image](https://github.com/andrewnguonly/Lumos/assets/7654246/cf948aaf-11e6-4610-aeb5-d3a189452c7f)
![image](https://github.com/andrewnguonly/Lumos/assets/7654246/9ff7ad8a-3842-42a3-af46-6c8b5a953dce)
