### PR TITLE
Unmount listeners so multiple listeners aren't added for each render

### DIFF
--- a/src/components/ChatBar.tsx
+++ b/src/components/ChatBar.tsx
@@ -251,6 +251,11 @@ const ChatBar: React.FC = () => {
   useEffect(() => {
     chrome.runtime.onMessage.addListener(handleBackgroundMessage);
     document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      chrome.runtime.onMessage.removeListener(handleBackgroundMessage);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
   });
 
   useEffect(() => {


### PR DESCRIPTION
This was causing multiple listeners to process the same `{done: true}` message.