### PR TITLE
Add ability to load clipboard content as a file attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Note: Content that is highlighted will not be cached in the vector store cache. 
 ## Shortcuts
 
 - `cmd + c`: Copy last message to clipboard.
+- `cmd + b`: Load clipboard text as a file attachment.
 - `cmd + j`: Toggle `Disable content parsing` checkbox.
 - `cmd + k`: Clear all messages.
 - `cmd + ;`: Open/close Chat History panel.
@@ -248,6 +249,10 @@ Image files will be processed through Lumos's [multimodal workflow](./docs/multi
 Supported image types:
 - `.jpeg`, `.jpg`
 - `.png`
+
+### Clipboard Content
+
+Clipboard content can be uploaded as a file attachment. Use the `cmd + b` shortcut key to load clipboard text as a file attachment.
 
 ## Tools (Experimental)
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "permissions": [
         "activeTab",
         "scripting",
-        "storage"
+        "storage",
+        "clipboardRead"
     ],
     "options_ui": {
         "page": "js/options.html",


### PR DESCRIPTION
### Summary
This PR is a workaround for https://github.com/andrewnguonly/Lumos/issues/167.

### Screenshot
![image](https://github.com/andrewnguonly/Lumos/assets/7654246/0176e615-8306-4d68-868b-c82e59d1bc7d)
