### PR TITLE
Disable parsing raw HTML in markdown

### DIFF
--- a/src/components/ChatBar.tsx
+++ b/src/components/ChatBar.tsx
@@ -727,6 +727,7 @@ const ChatBar: React.FC = () => {
                 <Message.CustomContent>
                   <Markdown
                     options={{
+                      disableParsingRawHTML: true,
                       overrides: {
                         pre: PreBlock,
                         code: CodeBlock,


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/andrewnguonly/Lumos/issues/193.